### PR TITLE
Bump down the minimum sdk version of the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Add the library in the dependency section of your application's `build.gradle` f
 ```groovy
 dependencies {
 	//consume library - use the latest version available on github packages
-	implementation "com.nerdstone:neat-android-stepper:1.0.0"
+	implementation "com.nerdstone:neat-android-stepper:1.0.3"
 	//....
 
 }

--- a/neat-android-stepper/build.gradle
+++ b/neat-android-stepper/build.gradle
@@ -3,12 +3,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'maven-publish'
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 28
+        minSdkVersion 18
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
 
@@ -55,7 +55,7 @@ def githubProperties = new Properties()
 githubProperties.load(new FileInputStream(rootProject.file("local.properties")))
 
 def getVersionName = { ->
-    return "1.0.2"
+    return "1.0.3"
 }
 
 def getArtifactId = { ->


### PR DESCRIPTION
Bump down the minimum sdk version of the library. [issue](https://github.com/ellykits/neat-android-stepper/issues/7)